### PR TITLE
use pandas for datetime conversion

### DIFF
--- a/basininflow/__init__.py
+++ b/basininflow/__init__.py
@@ -1,4 +1,4 @@
 from basininflow.inflow import create_inflow_file
 
-__version__ = '0.12.0'
+__version__ = '0.13.0'
 __all__ = ['create_inflow_file', ]

--- a/basininflow/inflow.py
+++ b/basininflow/inflow.py
@@ -221,8 +221,8 @@ def create_inflow_file(lsm_data: str,
     logging.info("Writing inflows to file")
     os.makedirs(inflow_dir, exist_ok=True)
     datetime_array = inflow_df.index.to_numpy()
-    start_date = datetime.datetime.fromtimestamp(datetime_array[0].astype(float) / 1e9, datetime.UTC).strftime('%Y%m%d')
-    end_date = datetime.datetime.fromtimestamp(datetime_array[-1].astype(float) / 1e9, datetime.UTC).strftime('%Y%m%d')
+    start_date = pd.to_datetime(datetime_array[0]).strftime('%Y%m%d')
+    end_date = pd.to_datetime(datetime_array[-1]).strftime('%Y%m%d')
     file_name = f'm3_{vpu_name}_{start_date}_{end_date}.nc'
     if file_label is not None:
         file_name = f'm3_{vpu_name}_{start_date}_{end_date}_{file_label}.nc'


### PR DESCRIPTION
Fixes bug with datetime.datetime.fromtimestamp not working with latest, unpinned version of python: 12 vs 11. Switch to using pandas.to_datetime so that the datetime module problem can be avoided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the application to version 0.13.0.
- **Bug Fixes**
	- Improved date formatting in the creation of inflow files by utilizing a more robust method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->